### PR TITLE
Rename NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# @skyux/media
+# @blackbaud/skyux-lib-media
 
-[![npm](https://img.shields.io/npm/v/@skyux/media.svg)](https://www.npmjs.com/package/@skyux/media)
-[![status](https://travis-ci.org/blackbaud/skyux-media.svg?branch=master)](https://travis-ci.org/blackbaud/skyux-media)
-[![coverage](https://codecov.io/gh/blackbaud/skyux-media/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/blackbaud/skyux-media/branch/master)
+[![npm](https://img.shields.io/npm/v/@blackbaud/skyux-lib-media.svg)](https://www.npmjs.com/package/@blackbaud/skyux-lib-media)
+[![status](https://travis-ci.org/blackbaud/skyux-lib-media.svg?branch=master)](https://travis-ci.org/blackbaud/skyux-lib-media)
+[![coverage](https://codecov.io/gh/blackbaud/skyux-lib-media/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/blackbaud/skyux-lib-media/branch/master)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skyux/media",
+  "name": "@blackbaud/skyux-lib-media",
   "version": "1.0.0-rc.1",
   "description": "SKY UX Media",
   "main": "bundles/bundle.umd.js",
@@ -22,12 +22,12 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@blackbaud/skyux-builder": "1.31.1",
-    "@blackbaud/skyux": "2.42.0",
-    "@skyux-sdk/builder-plugin-skyux": "1.0.0-rc.6"
+    "@blackbaud/skyux-builder": "1.33.1",
+    "@blackbaud/skyux": "2.46.1",
+    "@skyux-sdk/builder-plugin-skyux": "1.0.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/blackbaud/skyux-media.git"
+    "url": "https://github.com/blackbaud/skyux-lib-media.git"
   }
 }

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "skyux-media",
+  "name": "skyux-lib-media",
   "$schema": "./node_modules/@skyux/config/skyuxconfig-schema.json",
   "mode": "easy",
   "compileMode": "aot",


### PR DESCRIPTION
We're going to release this as `@blackbaud/skyux-lib-media` until we can carve out time in the SKY UX backlog to officially migrate all Stache-related modules.